### PR TITLE
Add pairlookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "watch-local": "graph deploy graphprotocol/Uniswap2 --watch --debug --node http://127.0.0.1:8020/ --ipfs http://localhost:5001"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "^0.23.2",
-    "@graphprotocol/graph-ts": "^0.23.1",
+    "@graphprotocol/graph-cli": "^0.28.0",
+    "@graphprotocol/graph-ts": "^0.26.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "eslint": "^6.2.2",

--- a/schema.graphql
+++ b/schema.graphql
@@ -299,3 +299,8 @@ type TokenDayData @entity {
   # price stats
   priceUSD: BigDecimal!
 }
+
+type PairLookup @entity {
+  id: ID!
+  pairAddress: Pair!
+}

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-const */
 import { log } from '@graphprotocol/graph-ts'
 import { PairCreated } from '../types/Factory/Factory'
-import { Bundle, Pair, Token, UniswapFactory } from '../types/schema'
+import { Bundle, Pair, Token, UniswapFactory, PairLookup } from '../types/schema'
 import { Pair as PairTemplate } from '../types/templates'
 import {
   BUNDLE_ID,
@@ -11,7 +11,7 @@ import {
   fetchTokenSymbol,
   fetchTokenTotalSupply,
   ZERO_BD,
-  ZERO_BI,
+  ZERO_BI
 } from './helpers'
 
 export function handleNewPair(event: PairCreated): void {
@@ -105,6 +105,22 @@ export function handleNewPair(event: PairCreated): void {
   pair.token0Price = ZERO_BD
   pair.token1Price = ZERO_BD
 
+  let pairLookup0 = new PairLookup(
+    token0.id
+      .toHexString()
+      .concat('-')
+      .concat(token1.id.toHexString())
+  )
+  pairLookup0.pairAddress = event.params.pair
+
+  let pairLookup1 = new PairLookup(
+    token1.id
+      .toHexString()
+      .concat('-')
+      .concat(token0.id.toHexString())
+  )
+  pairLookup1.pairAddress = event.params.pair
+
   // create the tracked contract based on the template
   PairTemplate.create(event.params.pair)
 
@@ -113,4 +129,6 @@ export function handleNewPair(event: PairCreated): void {
   token1.save()
   pair.save()
   factory.save()
+  pairLookup0.save()
+  pairLookup1.save()
 }

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -1,7 +1,16 @@
 /* eslint-disable prefer-const */
-import { Pair, Token, Bundle } from '../types/schema'
+import { Pair, Token, Bundle, PairLookup } from '../types/schema'
 import { BigDecimal, Address, BigInt, Bytes } from '@graphprotocol/graph-ts/index'
-import { ZERO_BD, factoryContract, ADDRESS_ZERO, ONE_BD, UNTRACKED_PAIRS, loadBundle, usdPrice, ethAmount } from './helpers'
+import {
+  ZERO_BD,
+  factoryContract,
+  ADDRESS_ZERO,
+  ONE_BD,
+  UNTRACKED_PAIRS,
+  loadBundle,
+  usdPrice,
+  ethAmount
+} from './helpers'
 
 const WETH_ADDRESS = Bytes.fromHexString('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2')
 const USDC_WETH_PAIR = Bytes.fromHexString('0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc') // created 10008355
@@ -83,9 +92,14 @@ export function findEthPerToken(token: Token): BigDecimal {
   let tokenAddr = Address.fromBytes(token.id)
   // loop through whitelist and check if paired with any
   for (let i = 0; i < WHITELIST.length; ++i) {
-    let pairAddress = factoryContract.getPair(tokenAddr, WHITELIST_ADDR[i])
-    if (pairAddress != ADDRESS_ZERO) {
-      let pair = Pair.load(pairAddress)
+    let pairLookup = PairLookup.load(
+      token.id
+        .toHexString()
+        .concat('-')
+        .concat(WHITELIST[i].toHexString())
+    )
+    if (pairLookup !== null && pairLookup.pairAddress != ADDRESS_ZERO) {
+      let pair = Pair.load(pairLookup.pairAddress)
       // If we don't know this pair, don't fail the subgraph
       if (pair) {
         if (pair.token0 == token.id && pair.reserveETH.gt(MINIMUM_LIQUIDITY_THRESHOLD_ETH)) {


### PR DESCRIPTION
This reduces an `eth_call` which is not necessary, instead caching the pairlookups in a subgraph entity ([example deployment](https://thegraph.com/hosted-service/subgraph/azf20/uniswap-v2?selected=playground))